### PR TITLE
Fix a typo (NETOPT_IP_INFO comment)

### DIFF
--- a/libctru/include/3ds/services/soc.h
+++ b/libctru/include/3ds/services/soc.h
@@ -16,7 +16,7 @@ typedef enum
 {
 	NETOPT_MAC_ADDRESS     = 0x1004, ///< The mac address of the interface (u32 mac[6])
 	NETOPT_ARP_TABLE       = 0x3002, ///< The ARP table @see SOCU_ARPTableEntry
-	NETOPT_IP_INFO         = 0x4003, ///< The cureent IP setup @see SOCU_IPInfo
+	NETOPT_IP_INFO         = 0x4003, ///< The current IP setup @see SOCU_IPInfo
 	NETOPT_IP_MTU          = 0x4004, ///< The value of the IP MTU (u32)
 	NETOPT_ROUTING_TABLE   = 0x4006, ///< The routing table @see SOCU_RoutingTableEntry
 	NETOPT_UDP_NUMBER      = 0x8002, ///< The number of sockets in the UDP table (u32)


### PR DESCRIPTION
Typo in NETOPT_IP_INFO comment which shows on the libctru docs.